### PR TITLE
Package json module key

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Dave Stewart",
   "license": "MIT",
   "main": "dist/vue-class-store.js",
-  "module": "dist/vue-class-store.esm.ts",
+  "module": "dist/vue-class-store.esm.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist/*",


### PR DESCRIPTION
I ran into this issue trying to set up vue-class-store with a vite project, which threw
`Internal server error: Failed to resolve entry for package "vue-class-store" The package may have incorrect main/module/exports specified in its package.json.`.

I have only tested this against the vue 3 branch.