### PR TITLE
Fixed vite compile error due to wrong module file

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Dave Stewart",
   "license": "MIT",
   "main": "dist/vue-class-store.js",
-  "module": "dist/vue-class-store.esm.ts",
+  "module": "dist/vue-class-store.esm.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist/*",


### PR DESCRIPTION
I got errors with vite
```The package may have incorrect main/module/exports specified in its package.json```
because the module-property in package.json directs to the wrong file.
Quickfix :)