### PR TITLE
Fix invalid typescript module path for v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Dave Stewart",
   "license": "MIT",
   "main": "dist/vue-class-store.js",
-  "module": "dist/vue-class-store.esm.ts",
+  "module": "dist/vue-class-store.esm.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist/*",


### PR DESCRIPTION
Hello @davestewart, thanks for the great package.

Could you accept this change and publish it for v3? Same change is already made on v2 but not in v3. Please push the change in npm with proper tag.

Thanks again!

Ref: https://github.com/davestewart/vue-class-store/pull/19